### PR TITLE
pv_avail: Ignore dynamically-provisioned PVs

### DIFF
--- a/check_openshift_pv_avail
+++ b/check_openshift_pv_avail
@@ -166,7 +166,10 @@ filter_volumes() {
     uidfilter+=".metadata.uid != \"$uid\""
   done
 
-  jqfilter='[.items[]'
+  jqfilter='[
+    .items[] |
+    select((.metadata.annotations["pv.kubernetes.io/provisioned-by"] // null) | not)
+  '
   if [[ -n "$uidfilter" ]]; then
     jqfilter+=" | select($uidfilter)"
   fi


### PR DESCRIPTION
Persistent volumes provisioned dynamically are marked with an annotation
("pv.kubernetes.io/provisioned-by"). These volumes aren't created
statically, hence it's perfectly valid to skip them in monitoring.