### PR TITLE
Handle pods without conditions in status object

### DIFF
--- a/check_openshift_pod_count
+++ b/check_openshift_pod_count
@@ -92,7 +92,7 @@ count_ready() {
   # https://godoc.org/k8s.io/kubernetes/pkg/api/v1>
   jq -r \
     '[.items[].status |
-      select(.conditions[] | select(.type == "Ready") | .status == "True")
+      select((.conditions // [])[] | select(.type == "Ready") | .status == "True")
      ] | length'
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.11.11) trusty; urgency=medium
+
+  * check_openshift_pod_count: Handle pods without conditions in status
+    object.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Wed, 07 Feb 2018 17:32:17 +0100
+
 nagios-plugins-openshift (0.11.10) trusty; urgency=medium
 
   * check_openshift_pv_avail: Fix typos and remove information no longer


### PR DESCRIPTION
When the eviction manager decides to move a pod to another node due to
resource pressure (i.e. memory) the pod ends up with a status object
without the "conditions" key. Handle this case in
"check_openshift_pod_count".