### PR TITLE
Check for Fluentd on all nodes

### DIFF
--- a/check_openshift_node_fluentd
+++ b/check_openshift_node_fluentd
@@ -75,10 +75,8 @@ fi
 
 # Data structure documentation:
 # https://godoc.org/k8s.io/kubernetes/pkg/api/v1>
-jq -r '
-  .items[] | select(.spec.unschedulable != true) | .metadata.name |
-  @text
-' < "$tmpdir/node.json" > "$tmpdir/node.txt"
+jq -r '.items[].metadata.name | @text' \
+  < "$tmpdir/node.json" > "$tmpdir/node.txt"
 
 filter_pods() {
   local node="$1"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.12.1) trusty; urgency=medium
+
+  * check_openshift_node_fluentd: Check all nodes, not only those marked
+    schedulable
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Mon, 05 Mar 2018 17:47:12 +0100
+
 nagios-plugins-openshift (0.11.12) trusty; urgency=medium
 
   * check_openshift_node, check_openshift_node_fluentd,

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.12.0
+Version: 0.12.1
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,6 +54,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Mon Mar 5 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.1-1
+- check_openshift_node_fluentd: Check all nodes, not only those marked
+  schedulable
+
 * Fri Feb 9 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.0-1
 - Initial version with most checks working on CentOS and RHEL.
 


### PR DESCRIPTION
The "check_openshift_node_fluentd" script didn't look at all nodes, but
only those marked schedulable. Normally master nodes are not schedulable
and hence monitoring wouldn't notice Fluentd not running on those.