### PR TITLE
Show additional info for pending and lost volume claims

### DIFF
--- a/check_openshift_pvc_phase
+++ b/check_openshift_pvc_phase
@@ -48,7 +48,13 @@ if ! msg=$(run_oc "$opt_cfgfile" get pvc \
 fi
 
 jq -r '.items[] |
-  @sh "name=\(.metadata.namespace + "/" + .metadata.name) phase=\(.status.phase)"
+  @sh " \\
+    name=\(.metadata.namespace + "/" + .metadata.name) \\
+    phase=\(.status.phase) \\
+    volname=\(.spec.volumeName // "") \\
+    reqstorage=\(.spec.resources.requests.storage // "") \\
+    capacity=\(.status.capacity.storage // "") \\
+  "
   ' \
   < "$tmpdir/data.json" > "$tmpdir/parsed.sh"
 
@@ -71,16 +77,36 @@ while read line; do
 
   let "++phase_count[$lc_phase]"
 
+  info=()
+
+  if [[ -n "$reqstorage" ]]; then
+    info+=( "req size: ${reqstorage}" )
+  fi
+
+  if [[ -n "$capacity" ]]; then
+    info+=( "capacity: ${capacity}" )
+  fi
+
+  if [[ -n "$volname" ]]; then
+    info+=( "PV name: ${volname}" )
+  fi
+
+  if [[ -n "${info[*]+${info[*]}}" ]]; then
+    infostr="${name} ($(join_args ', ' "${info[@]}"))"
+  else
+    infostr="$name"
+  fi
+
   # https://github.com/kubernetes/kubernetes/blob/v1.3.4/pkg/api/v1/types.go#L514
   case "$lc_phase" in
     bound) ;;
 
     pending)
-      pending_claims+=( "$name" )
+      pending_claims+=( "$infostr" )
       ;;
 
     lost)
-      lost_claims+=( "$name" )
+      lost_claims+=( "$infostr" )
       ;;
 
     *)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.12.3) trusty; urgency=medium
+
+  * check_openshift_pvc_phase: Show requested size, volume name and bound
+    capacity for pending and lost claims.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Tue, 03 Apr 2018 14:58:57 +0200
+
 nagios-plugins-openshift (0.12.2) trusty; urgency=medium
 
   * Update openshift-origin-client-tools dependency to require version 3.7.2

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.12.2
+Version: 0.12.3
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,6 +54,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Mon Apr 3 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.3-1
+- check_openshift_pvc_phase: Show requested size, volume name and bound
+  capacity for pending and lost claims.
+
 * Thu Mar 22 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.2-1
 - Install "new-app-and-wait" script.
 - Update openshift-origin-client-tools dependency to require version 3.7.2 or


### PR DESCRIPTION
Amend the "check_openshift_pvc_phase" script to show requested size,
volume name and bound capacity for pending and lost claims. These bits
can be useful in resolving issues and save the operator from having to
look them up on the cluster.