### PR TITLE
Specify temporary directory for "oc new-app"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nagios-plugins-openshift (0.12.4) trusty; urgency=medium
+
+  * new-app-and-wait: The upstream code for "oc new-app" can leave a clone of
+    the application source behind in a temporary directory. Explicitly specify
+    a temporary directory which is then removed by the wrapper code.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Wed, 04 Apr 2018 14:39:24 +0200
+
 nagios-plugins-openshift (0.12.3) trusty; urgency=medium
 
   * check_openshift_pvc_phase: Show requested size, volume name and bound

--- a/new-app-and-wait
+++ b/new-app-and-wait
@@ -7,6 +7,7 @@ import logging
 import re
 import socket
 import subprocess
+import tempfile
 import time
 import urllib3
 
@@ -132,17 +133,20 @@ class ExpectedPatternContext(retry.UrlWaitContext):
 def Check(client, args, timeout):
   appname = "testapp"
 
-  create_cmd = [
-    "new-app",
-    "--name={}".format(appname),
-    args.source,
-    ]
+  with tempfile.TemporaryDirectory() as tmpdir:
+    create_cmd = [
+      "new-app",
+      "--name={}".format(appname),
+      args.source,
+      ]
 
-  if args.strategy is not None:
-    create_cmd.append("--strategy={}".format(args.strategy))
+    if args.strategy is not None:
+      create_cmd.append("--strategy={}".format(args.strategy))
 
-  logging.info("Creating application from %s", args.source)
-  client.run(create_cmd)
+    logging.info("Creating application from %s", args.source)
+    client.run(create_cmd, env_override={
+      "TMPDIR": tmpdir,
+      })
 
   client.run(["expose", "svc", appname])
 

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.12.3
+Version: 0.12.4
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,7 +54,12 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
-* Mon Apr 3 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.3-1
+* Wed Apr 4 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.4-1
+- new-app-and-wait: The upstream code for "oc new-app" can leave a clone of the
+  application source behind in a temporary directory. Explicitly specify
+  a temporary directory which is then removed by the wrapper code.
+
+* Tue Apr 3 2018 Michael Hanselmann <hansmi@vshn.ch> 0.12.3-1
 - check_openshift_pvc_phase: Show requested size, volume name and bound
   capacity for pending and lost claims.
 

--- a/vshn_npo/oc_client.py
+++ b/vshn_npo/oc_client.py
@@ -1,3 +1,4 @@
+import os
 import base64
 import contextlib
 import functools
@@ -110,7 +111,7 @@ class Client:
 
     return result
 
-  def run(self, args, ignore_errors=False):
+  def run(self, args, ignore_errors=False, env_override=None):
     """Run OpenShift client.
 
     :param args: Arguments to pass to OpenShift client.
@@ -121,12 +122,18 @@ class Client:
     cmd.extend(args)
     logging.debug("%r", cmd)
 
+    if env_override:
+      env = os.environ.copy()
+      env.update(env_override)
+    else:
+      env = None
+
     if ignore_errors:
       fn = subprocess.call
     else:
       fn = subprocess.check_call
 
-    fn(cmd)
+    fn(cmd, env=env)
 
   def capture_output(self, args):
     cmd = self._make_base_cmd()


### PR DESCRIPTION
The upstream code for "oc new-app" can leave a clone of the application
source behind in a temporary directory. Explicitly specify a temporary
directory which is then removed by the wrapper code to prevent code from
being left behind.