### PR TITLE
`oc` client path identification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ all:	#nothing to build
 install:
 	mkdir -p $(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift
 	cp new-app-and-wait "$(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift/new-app-and-wait"
-	sed -r \
-		-e 's#\b(OPENSHIFT_CLIENT_BINARY=)/usr/bin/oc\b#\1$(LIBDIR)/openshift-origin-client-tools/oc#' \
-		< utils \
-		> "$(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift/utils"
+	cp utils "$(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift/utils"
 	sed -r \
 		-e 's#(^\. )/usr/lib(/nagios-plugins-openshift/utils)$$#\1$(LIBDIR)\2#g' \
 		< write-config \

--- a/utils
+++ b/utils
@@ -5,7 +5,7 @@ readonly state_warning=1
 readonly state_critical=2
 readonly state_unknown=3
 
-readonly OPENSHIFT_CLIENT_BINARY=/usr/bin/oc
+readonly OPENSHIFT_CLIENT_BINARY=$(which oc)
 
 #
 # Print arguments joined by delimiter


### PR DESCRIPTION
I'm very happy to discover these checks command for OCP but I had some issues during installation: Makefile replaced with the OpenShift Client tool path causing some issues, using `which` everything works fine.