### PR TITLE
Expose total pod count as Icinga2 variable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.13.1) trusty; urgency=medium
+
+  * Expose count over all pod phases in "check_openshift_project_pod_phase" as
+    Icinga2 variable.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Fri, 27 Apr 2018 11:39:31 +0200
+
 nagios-plugins-openshift (0.13.0) trusty; urgency=medium
 
   * Add "check_openshift_project_pod_phase" script to observe pod phase

--- a/openshift.conf
+++ b/openshift.conf
@@ -404,8 +404,11 @@ object CheckCommand "openshift_project_pod_phase" {
 
   command += [PluginDir + "/check_openshift_project_pod_phase"]
 
-  # https://godoc.org/k8s.io/api/core/v1#PodPhase
   var _phases = [
+    # All phases
+    "count",
+
+    # https://godoc.org/k8s.io/api/core/v1#PodPhase
     "pending",
     "running",
     "succeeded",

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.13.0
+Version: 0.13.1
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,6 +54,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Fri Apr 27 2018 Michael Hanselmann <hansmi@vshn.ch> 0.13.1-1
+- Expose count over all pod phases in "check_openshift_project_pod_phase" as
+  Icinga2 variable.
+
 * Thu Apr 26 2018 Michael Hanselmann <hansmi@vshn.ch> 0.13.0-1
 - Add "check_openshift_project_pod_phase" script to observe pod phase (pending,
   running, etc.) of all pods on a cluster.


### PR DESCRIPTION
The "check_openshift_project_pod_phase" plugin can also evaluate the
total number of pods per project. Expose that as a dedicated Icinga2
variable.