### PR TITLE
Replace lambdas with direct runtime macro access

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nagios-plugins-openshift (0.14.1) trusty; urgency=medium
+
+  * Icinga check command "openshift_node_resources": Replace lambdas in
+    "skip_if" with direct access to runtime macros. Now arguments are passed
+    onto the check script even if they're not a string.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Mon, 18 Jun 2018 17:51:02 +0200
+
 nagios-plugins-openshift (0.14.0) trusty; urgency=medium
 
   * check_openshift_pv_avail: The selector options "-l" and "-s" now support

--- a/openshift.conf
+++ b/openshift.conf
@@ -41,7 +41,7 @@ template CheckCommand "openshift-arg-selector" {
       value    = "$openshift_selector$"
       required = true
       order    = -80
-      set_if   = {{ len(macro("$openshift_selector$")) > 0 }}
+      set_if   = "$openshift_selector$"
     }
   }
 }
@@ -82,7 +82,7 @@ template CheckCommand "openshift-arg-selector-py" {
       value    = "$openshift_selector$"
       required = true
       order    = -70
-      set_if   = {{ len(macro("$openshift_selector$")) > 0 }}
+      set_if   = "$openshift_selector$"
     }
   }
 }
@@ -329,42 +329,42 @@ object CheckCommand "openshift_node_resources" {
     "cpu-limits-warn" = {
       key = "-w"
       value = "cpu-limits=$openshift_node_cpu_limits_warn$"
-      set_if = {{ len(macro("$openshift_node_cpu_limits_warn$")) > 0 }}
+      set_if = "$openshift_node_cpu_limits_warn$"
     }
     "cpu-limits-critical" = {
       key = "-c"
       value = "cpu-limits=$openshift_node_cpu_limits_critical$"
-      set_if = {{ len(macro("$openshift_node_cpu_limits_critical$")) > 0 }}
+      set_if = "$openshift_node_cpu_limits_critical$"
     }
     "cpu-requests-warn" = {
       key = "-w"
       value = "cpu-requests=$openshift_node_cpu_requests_warn$"
-      set_if = {{ len(macro("$openshift_node_cpu_requests_warn$")) > 0 }}
+      set_if = "$openshift_node_cpu_requests_warn$"
     }
     "cpu-requests-critical" = {
       key = "-c"
       value = "cpu-requests=$openshift_node_cpu_requests_critical$"
-      set_if = {{ len(macro("$openshift_node_cpu_requests_critical$")) > 0 }}
+      set_if = "$openshift_node_cpu_requests_critical$"
     }
     "memory-limits-warn" = {
       key = "-w"
       value = "memory-limits=$memory_limits_warn$"
-      set_if = {{ len(macro("$memory_limits_warn$")) > 0 }}
+      set_if = "$memory_limits_warn$"
     }
     "memory-limits-critical" = {
       key = "-c"
       value = "memory-limits=$openshift_node_memory_limits_critical$"
-      set_if = {{ len(macro("$openshift_node_memory_limits_critical$")) > 0 }}
+      set_if = "$openshift_node_memory_limits_critical$"
     }
     "memory-requests-warn" = {
       key = "-w"
       value = "memory-requests=$openshift_node_memory_requests_warn$"
-      set_if = {{ len(macro("$openshift_node_memory_requests_warn$")) > 0 }}
+      set_if = "$openshift_node_memory_requests_warn$"
     }
     "memory-requests-critical" = {
       key = "-c"
       value = "memory-requests=$openshift_node_memory_requests_critical$"
-      set_if = {{ len(macro("$openshift_node_memory_requests_critical$")) > 0 }}
+      set_if = "$openshift_node_memory_requests_critical$"
     }
   }
 }

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.14.0
+Version: 0.14.1
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,6 +54,11 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Mon Jun 18 2018 Michael Hanselmann <hansmi@vshn.ch> 0.14.1-1
+- Icinga check command "openshift_node_resources": Replace lambdas in "skip_if"
+  with direct access to runtime macros. Now arguments are passed onto the check
+  script even if they're not a string.
+
 * Fri May 4 2018 Michael Hanselmann <hansmi@vshn.ch> 0.14.0-1
 - check_openshift_pv_avail: The selector options "-l" and "-s" now support an
   optional storage class, separated from the value by a comma. To retain the


### PR DESCRIPTION
The arguments for the "openshift_node_resources" check command used
"skip_if" with a lambda. The intention was to only set arguments when
they expanded to a string at least one character in length.

Most deployments configure the variables, i.e.
"openshift_node_cpu_limits_warn", to numbers. Those deployments never
saw limit arguments to "openshift_node_resources" applied.

The "macro" function does not automatically convert values to strings.
Instead the Icinga2 script language returns them in their original type
if and only if they're the only expanded macro ("macro("$foo$=$bar$")"
produces a string with "foo" and "bar" expanded, "macro("$num$")"'s
return type depends on the expanded variable).

The global "len" function is not recommended and the Icinga2
documentation[1] advises to use type-specific functions instead (i.e.
String#len).

The implementation of the global "len" function silently returns 0 for
unrecognized types such as Number. In this case the lambda given to
"skip_if" would call "len" on a Number, always getting a length of zero
and thus skipping arguments.

One option would've been to use the "string" function, i.e.
"len(string(macro("$…$"))) > 0". Another is to do away with the lambdas
altogether and to rely on the implicit conversion to Boolean[3] instead.
The latter option is implemented with this change.

[1]
https://www.icinga.com/docs/icinga2/latest/doc/18-library-reference/#len

[2]
https://github.com/Icinga/icinga2/blob/v2.8.4/lib/base/scriptutils.cpp#L232

[3]
https://www.icinga.com/docs/icinga2/latest/doc/17-language-reference/#boolean-values