### PR TITLE
Re-introduce lambdas for "set_if"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.14.2) trusty; urgency=medium
+
+  * Fix a bug introduced in version 0.14.1: Selector arguments for check
+    commands were silently skipped. Only a warning was logged.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Tue, 19 Jun 2018 15:17:17 +0200
+
 nagios-plugins-openshift (0.14.1) trusty; urgency=medium
 
   * Icinga check command "openshift_node_resources": Replace lambdas in

--- a/openshift.conf
+++ b/openshift.conf
@@ -41,7 +41,7 @@ template CheckCommand "openshift-arg-selector" {
       value    = "$openshift_selector$"
       required = true
       order    = -80
-      set_if   = "$openshift_selector$"
+      set_if   = {{ bool(macro("$openshift_selector$")) }}
     }
   }
 }
@@ -82,7 +82,7 @@ template CheckCommand "openshift-arg-selector-py" {
       value    = "$openshift_selector$"
       required = true
       order    = -70
-      set_if   = "$openshift_selector$"
+      set_if   = {{ bool(macro("$openshift_selector$")) }}
     }
   }
 }
@@ -329,42 +329,42 @@ object CheckCommand "openshift_node_resources" {
     "cpu-limits-warn" = {
       key = "-w"
       value = "cpu-limits=$openshift_node_cpu_limits_warn$"
-      set_if = "$openshift_node_cpu_limits_warn$"
+      set_if = {{ bool(macro("$openshift_node_cpu_limits_warn$")) }}
     }
     "cpu-limits-critical" = {
       key = "-c"
       value = "cpu-limits=$openshift_node_cpu_limits_critical$"
-      set_if = "$openshift_node_cpu_limits_critical$"
+      set_if = {{ bool(macro("$openshift_node_cpu_limits_critical$")) }}
     }
     "cpu-requests-warn" = {
       key = "-w"
       value = "cpu-requests=$openshift_node_cpu_requests_warn$"
-      set_if = "$openshift_node_cpu_requests_warn$"
+      set_if = {{ bool(macro("$openshift_node_cpu_requests_warn$")) }}
     }
     "cpu-requests-critical" = {
       key = "-c"
       value = "cpu-requests=$openshift_node_cpu_requests_critical$"
-      set_if = "$openshift_node_cpu_requests_critical$"
+      set_if = {{ bool(macro("$openshift_node_cpu_requests_critical$")) }}
     }
     "memory-limits-warn" = {
       key = "-w"
       value = "memory-limits=$memory_limits_warn$"
-      set_if = "$memory_limits_warn$"
+      set_if = {{ bool(macro("$memory_limits_warn$")) }}
     }
     "memory-limits-critical" = {
       key = "-c"
       value = "memory-limits=$openshift_node_memory_limits_critical$"
-      set_if = "$openshift_node_memory_limits_critical$"
+      set_if = {{ bool(macro("$openshift_node_memory_limits_critical$")) }}
     }
     "memory-requests-warn" = {
       key = "-w"
       value = "memory-requests=$openshift_node_memory_requests_warn$"
-      set_if = "$openshift_node_memory_requests_warn$"
+      set_if = {{ bool(macro("$openshift_node_memory_requests_warn$")) }}
     }
     "memory-requests-critical" = {
       key = "-c"
       value = "memory-requests=$openshift_node_memory_requests_critical$"
-      set_if = "$openshift_node_memory_requests_critical$"
+      set_if = {{ bool(macro("$openshift_node_memory_requests_critical$")) }}
     }
   }
 }
@@ -433,7 +433,9 @@ object CheckCommand "openshift_project_pod_phase" {
           )
 
         arguments[_macro_suffix] = {
-          set_if = _macro_placeholder
+          set_if = function () use (_macro_placeholder) {
+            bool(_macro_placeholder)
+          }
           key = "-" + type.substr(0, 1)
           value = scope + "." + phase + "=" + _macro_placeholder
         }

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.14.1
+Version: 0.14.2
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -54,6 +54,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Tue Jun 19 2018 Michael Hanselmann <hansmi@vshn.ch> 0.14.2-1
+- Fix a bug introduced in version 0.14.1: Selector arguments for check commands
+  were silently skipped. Only a warning was logged.
+
 * Mon Jun 18 2018 Michael Hanselmann <hansmi@vshn.ch> 0.14.1-1
 - Icinga check command "openshift_node_resources": Replace lambdas in "skip_if"
   with direct access to runtime macros. Now arguments are passed onto the check


### PR DESCRIPTION
Commit d9f280e fixed a bug due to which "openshift_node_resources"
arguments with numeric values would be silently skipped. As part of that
change the templates for passing selectors to commands,
"openshift-arg-selector" and "openshift-arg-selector-py", were also
changed to use "set_if = "$…$"" rather than calling "len(macro(…))".

Unfortunately that change brought about another issue: "set_if" requires
its value to be either the string "true" or "false", or a value that can
be converted to an integral number. An argument is then only used when
the number is not zero. In the case of "openshift_node_resources" that
was the case as the variables are numbers.

Selectors are usually of the form "label=value". Checks using the
selector templates would have the selector silently dropped. Icinga logs
a warning ("Can't convert '…' to a floating point number") which was
missed during testing.

With this change we're changing all uses of "set_if" to use a lambda
function expanding the macro and passing the expanded value through the
"bool" function, thus implementing the same logic as the implicit
conversions to boolean[1].

[1]
https://www.icinga.com/docs/icinga2/latest/doc/17-language-reference/#boolean-values