### PR TITLE
node_log_heartbeat: Make query work with OpenShift Origin 3.9

### DIFF
--- a/check_openshift_node_log_heartbeat
+++ b/check_openshift_node_log_heartbeat
@@ -47,7 +47,11 @@ def make_query(query_from, query_to, expected_hostcount):
                 },
               },
               {
-                "term": {
+                # FIXME: In OpenShift Origin 3.9 the field is analyzed and
+                # can't be matched for exact equality. Must be switched to
+                # "term" once the field is no longer analyzed (as is the case
+                # in OpenShift Container Platform 3.9).
+                "match": {
                   "systemd.u.SYSLOG_IDENTIFIER":
                     "syslog-heartbeat-profile_openshift3",
                 },

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+nagios-plugins-openshift (0.15.2) trusty; urgency=medium
+
+  node_log_heartbeat:
+  * Change part of the Elasticsearch filter from "term" to "match" query to
+    support differences in fields between OpenShift Origin 3.9 and OpenShift
+    Container Platform 3.9.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Thu, 15 Nov 2018 11:35:33 +0100
+
 nagios-plugins-openshift (0.15.1) trusty; urgency=medium
 
   node_log_heartbeat:

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.15.1
+Version: 0.15.2
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -53,6 +53,12 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Thu Nov 15 2018 Michael Hanselmann <hansmi@vshn.ch> 0.15.2-1
+- node_log_heartbeat:
+  - Change part of the Elasticsearch filter from "term" to "match" query to
+    support differences in fields between OpenShift Origin 3.9 and OpenShift
+    Container Platform 3.9.
+
 * Wed Nov 14 2018 Michael Hanselmann <hansmi@vshn.ch> 0.15.1-1
 - node_log_heartbeat:
   - Add unit-of-measurement to metrics


### PR DESCRIPTION
In OpenShift Origin 3.9 the field "systemd.u.SYSLOG_IDENTIFIER" is
analyzed and can't be matched for exact equality. Instead the "match"
filter must be used.