### PR TITLE
pv_avail: Replace "default class" with "without storage class"

### DIFF
--- a/check_openshift_pv_avail
+++ b/check_openshift_pv_avail
@@ -268,7 +268,7 @@ check() {
 
     if [[ -z "$storageclass" ]]; then
       scmetric=
-      scoutput=" in default class"
+      scoutput=" without storage class"
     else
       scmetric="${storageclass}-"
       scoutput=" in class \"${storageclass}\""


### PR DESCRIPTION
Persistent volume objects without a storage class name aren't
necessarily in the default storage class. Name them for what they are.