### PR TITLE
object_stats: Allow restricting namespace

### DIFF
--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -225,7 +225,7 @@ reduce .items[] as $obj ({};
       $obj.status? as $job_status |
       if $job_status then
         (
-          $obj.metadata?.ownerReferences? |
+          ($obj.metadata?.ownerReferences? // []) |
           map(select(.controller and (.kind? | ascii_downcase) == "cronjob")) |
           first
         ) as $controller |

--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -7,13 +7,14 @@ set -e -u -o pipefail
 default_reskind=pod,cronjob,job
 
 usage() {
-  echo "Usage: $0 -f <path> [-t <kind>[,<kind>]]"\
+  echo "Usage: $0 -f <path> [-n <ns>] [-t <kind>[,<kind>]]"\
     '[{ -W | -C } <regex>=<number>] [{ -w | -c } <name>=<number>]'
   echo
   echo 'Collect statistics on OpenShift objects.'
   echo
   echo 'Options:'
   echo ' -f             Config file path'
+  echo ' -n             Namespace (defaults to all namespaces)'
   echo ' -t             Resource kind, separate multiple with comma' \
     "(default: ${default_reskind})"
   echo ' -w name=value  Warn if given performance metric is more than given'\
@@ -78,15 +79,17 @@ add_limit() {
 }
 
 opt_cfgfile=
+opt_namespace=
 opt_reskind="$default_reskind"
 
-while getopts 'hf:t:w:c:W:C:' opt; do
+while getopts 'hf:n:t:w:c:W:C:' opt; do
   case "$opt" in
     h)
       usage
       exit 0
       ;;
     f) opt_cfgfile="$OPTARG" ;;
+    n) opt_namespace="$OPTARG" ;;
     t) opt_reskind="$OPTARG" ;;
     w) add_limit plain warn "$OPTARG" ;;
     c) add_limit plain crit "$OPTARG" ;;
@@ -109,9 +112,14 @@ fi
 oc_args=(
   get
   "$opt_reskind"
-  --all-namespaces
   --output=json
   )
+
+if [[ -z "$opt_namespace" ]]; then
+  oc_args+=( --all-namespaces )
+else
+  oc_args+=( -n "$opt_namespace" )
+fi
 
 # Capture stderr in variable and redirect stdout to file
 # shellcheck disable=SC2069

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.17.1) xenial; urgency=medium
+
+  * check_openshift_object_stats: Support additional "-n" parameter to specify
+    namespace. By default objects from all namespaces are retrieved.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Thu, 31 Jan 2019 13:46:58 +0100
+
 nagios-plugins-openshift (0.17.0) xenial; urgency=medium
 
   * check_openshift_object_stats: New plugin to compute object statistics

--- a/debian/files
+++ b/debian/files
@@ -1,0 +1,1 @@
+nagios-plugins-openshift_0.17.0_source.buildinfo net optional

--- a/openshift.conf
+++ b/openshift.conf
@@ -27,14 +27,20 @@ template CheckCommand "openshift-arg-config-file-py" {
   }
 }
 
-template CheckCommand "openshift-arg-namespace" {
+template CheckCommand "openshift-arg-namespace-optional" {
   arguments += {
     "-n" = {
       value    = "$openshift_namespace$"
-      required = true
+      required = false
       order    = -90
     }
   }
+}
+
+template CheckCommand "openshift-arg-namespace" {
+  import "openshift-arg-namespace-optional"
+
+  arguments["-n"].required = true
 }
 
 template CheckCommand "openshift-arg-selector" {
@@ -440,6 +446,7 @@ object CheckCommand "openshift_object_stats" {
   import "plugin-check-command"
   import "openshift-sudo-command"
   import "openshift-arg-config-file"
+  import "openshift-arg-namespace-optional"
 
   timeout = 60
 

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.17.0
+Version: 0.17.1
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -53,6 +53,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Thu Jan 31 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.1-1
+- check_openshift_object_stats: Support additional "-n" parameter to specify
+  namespace. By default objects from all namespaces are retrieved.
+
 * Tue Jan 29 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.0-1
 - check_openshift_object_stats: New plugin to compute object statistics based
   on "check_openshift_project_pod_phase". The latter will be removed in an


### PR DESCRIPTION
In commit 64c81d7 a new plugin, "check_openshift_object_stats" was
added. It would compute statistics over objects from all namespaces.
There are cases where that's undesired, hence this change adds an
optional parameter to specify the namespace.