### PR TITLE
object_stats: Output only metrics with limits by default

### DIFF
--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -405,10 +405,20 @@ to_entries | map(
     .msg = "\(.name) of \(.value) larger than \(.warn)"
   else
     .status = $state_ok
-  end
-) |
+  end |
+  .output = verbose or (
+    (
+      .status == $state_ok and
+      .warn == null and
+      .crit == null and
+      .msg == null
+    ) | not
+    )
+) as $perfdata_all |
 
-# Sort by status and name
+# Sort metrics for output by status and name
+$perfdata_all |
+map(select(.output)) |
 sort_by(
   [(
     if .status == $state_critical then
@@ -435,12 +445,25 @@ $perfdata | first | (.status // $state_unknown) as $exit_status |
 (
   (
     ($perfdata | sort_by(.name)) + [
-      # Add number of metrics
-      {
-        "name": "perfdata.count",
-        "value": ($perfdata | length),
-        "min": 0
-      }
+      (
+        ($perfdata | length) as $perfdata_count |
+        ($perfdata_all | length) as $perfdata_all_count |
+
+        # Add number of metrics
+        {
+          "name": "perfdata.all.count",
+          "value": $perfdata_all_count
+        },
+        {
+          "name": "perfdata.selected.count",
+          "value": $perfdata_count
+        },
+        {
+          "name": "perfdata.filtered.count",
+          "value": ($perfdata_all_count - $perfdata_count)
+        }
+      ) |
+      .min = 0
     ]
   ) |
   map("\u0027\(.name)\u0027=\(.value)\(.uom // "");\(.warn // "");\(.crit // "");\(.min // "")") |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.17.3) xenial; urgency=medium
+
+  check_openshift_object_stats:
+  * Output only metrics with defined limits or an unhealthy status.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Wed, 06 Feb 2019 12:49:18 +0100
+
 nagios-plugins-openshift (0.17.2) xenial; urgency=medium
 
   check_openshift_object_stats:

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.17.2
+Version: 0.17.3
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -53,6 +53,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Wed Feb 6 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.3-1
+- check_openshift_object_stats:
+  - Output only metrics with defined limits or an unhealthy status.
+
 * Tue Feb 5 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.2-1
 - check_openshift_object_stats:
   - Add verbose mode for easier debugging.


### PR DESCRIPTION
The "check_openshift_object_stats" script can generate very large
numbers of performance metrics, leading Icinga to truncate the list.
With this change only metrics with defined limits or an unhealthy status
are output. In verbose mode all metrics are output.