### PR TITLE
object_stats: Return OK without metrics

### DIFF
--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -439,7 +439,7 @@ $perfdata | map(
 ) as $messages |
 
 # Values are sorted by severity, thus the first is also the worst
-$perfdata | first | (.status // $state_unknown) as $exit_status |
+(($perfdata | first | .status) // $state_ok) as $exit_status |
 
 # Format metrics
 (

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.17.4) xenial; urgency=medium
+
+  check_openshift_object_stats:
+  * Return "OK" status when there are no metrics.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Thu, 21 Mar 2019 18:02:00 +0100
+
 nagios-plugins-openshift (0.17.3) xenial; urgency=medium
 
   check_openshift_object_stats:

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.17.3
+Version: 0.17.4
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -53,6 +53,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Thu Mar 21 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.4-1
+- check_openshift_object_stats:
+  - Return "OK" status when there are no metrics.
+
 * Wed Feb 6 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.3-1
 - check_openshift_object_stats:
   - Output only metrics with defined limits or an unhealthy status.


### PR DESCRIPTION
When there are no metrics to report the exit status was "unknown". That
could be confusing.