### PR TITLE
es_stats: Use Elasticsearch instance name in metrics

### DIFF
--- a/check_openshift_es_stats
+++ b/check_openshift_es_stats
@@ -80,10 +80,12 @@ class StatsQuery(nagiosplugin.Resource):
       # In a cluster outside OpenShift there could be more than one
       # Elasticsearch instance per host, but in OpenShift every container has
       # its own name.
-      suffix = node["host"]
+      suffix = node["name"]
 
-      if suffix.startswith(self._strip_hostname_prefix):
-        suffix = suffix[len(self._strip_hostname_prefix):]
+      for i in self._strip_hostname_prefix:
+        if suffix.startswith(i):
+          suffix = suffix[len(i):]
+          break
 
       for i in itertools.chain(_FsStats(suffix, node["fs"]),
                                _ProcessStats(suffix, node["process"]),
@@ -97,7 +99,7 @@ def main():
   utils.add_verbose_argument(parser)
   utils.add_token_arguments(parser)
   parser.add_argument("--strip-hostname-prefix", metavar="PREFIX",
-                      default="logging-es-",
+                      action="append",
                       help="Strip given prefix from node names")
   parser.add_argument("--fs-used-warn", metavar="RANGE",
                       help="Warn if consumed disk space is above given percentage")
@@ -116,6 +118,13 @@ def main():
                       help="API endpoint")
 
   args = parser.parse_args()
+
+  # Workaround for https://bugs.python.org/issue16399
+  if not args.strip_hostname_prefix:
+    args.strip_hostname_prefix = [
+      "logging-es-data-master-",
+      "logging-es-",
+    ]
 
   utils.setup_basic_logging(args.verbose)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+nagios-plugins-openshift (0.17.5) xenial; urgency=medium
+
+  check_openshift_es_stats:
+  * Use Elasticsearch instance name as metric suffix.
+  * Strip "logging-es-data-master-" and "logging-es-" prefixes from instance
+    name.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Fri, 29 Mar 2019 12:25:56 +0100
+
 nagios-plugins-openshift (0.17.4) xenial; urgency=medium
 
   check_openshift_object_stats:

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.17.4
+Version: 0.17.5
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -53,6 +53,12 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Fri Mar 29 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.5-1
+- check_openshift_es_stats:
+  - Use Elasticsearch instance name as metric suffix.
+  - Strip "logging-es-data-master-" and "logging-es-" prefixes from instance
+    name.
+
 * Thu Mar 21 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.4-1
 - check_openshift_object_stats:
   - Return "OK" status when there are no metrics.


### PR DESCRIPTION
Since at least early 2018 OpenShift has used the deployment
configuration's name with its random suffix as the name for each
Elasticsearch instance. At the time of commit c04a18c that wasn't the
case yet. Unlike the "host" key, an IP address, the deployment
configuration name can easily be identified in a list of objects.

At the same time the functionality to strip prefixes from names is
amended with the ability to specify multiple and the default list is
extended to include "logging-es-data-master-".