### PR TITLE
Explicitly use Python 3.4 on CentOS/RHEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@ all:	#nothing to build
 
 install:
 	mkdir -p $(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift
-	cp new-app-and-wait "$(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift/new-app-and-wait"
+	for i in new-app-and-wait; do \
+		sed -r \
+			-e '1 s|^(#!/usr/bin/python)3$$|\13.4|' \
+			< "$$i" \
+			> "$(DESTDIR)/$(LIBDIR)/nagios-plugins-openshift/$$(basename "$$i")"; \
+	done
 	sed -r \
 		-e 's#\b(OPENSHIFT_CLIENT_BINARY=)/usr/bin/oc\b#\1$(LIBDIR)/openshift-origin-client-tools/oc#' \
 		< utils \
@@ -18,7 +23,9 @@ install:
 	mkdir -p $(DESTDIR)/$(LIBDIR)/nagios/plugins
 	set -e && for i in check_*; do \
 		echo "Patching $$i ..." >&2 && \
-		sed -re 's#(^\. )/usr/lib(/nagios-plugins-openshift/utils)$$#\1$(LIBDIR)\2#g' \
+		sed -r \
+			-e '1 s|^(#!/usr/bin/python)3$$|\13.4|' \
+			-e 's#(^\. )/usr/lib(/nagios-plugins-openshift/utils)$$#\1$(LIBDIR)\2#g' \
 			< "$$i" \
 			> "$(DESTDIR)/$(LIBDIR)/nagios/plugins/$$(basename "$$i")"; \
 	done

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,7 +1,7 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
 Version: 0.17.5
-Release: 1
+Release: 2
 License: BSD-3-Clause
 Source: .
 URL: https://github.com/appuio/nagios-plugins-openshift
@@ -18,6 +18,8 @@ Requires: python3-nagiosplugin >= 1.2
 Requires: python34-requests >= 2.12
 Requires: python34-urllib3 >= 1.13
 Requires: python34-dateutil
+
+%define __python3 /usr/bin/python3.4
 
 %package config
 Requires: icinga2, nagios-plugins-sudo-config
@@ -53,6 +55,11 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Tue Apr 9 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.5-2
+- Patch Python programs to explicitly invoke "/usr/bin/python3.4" instead of
+  "/usr/bin/python3" to handle differences in the installed default Python
+  version.
+
 * Fri Mar 29 2019 Michael Hanselmann <hansmi@vshn.ch> 0.17.5-1
 - check_openshift_es_stats:
   - Use Elasticsearch instance name as metric suffix.


### PR DESCRIPTION
The "python3-nagiosplugin" package is built against Python 3.4. With the
default Python version on CentOS/RHEL having become 3.6 recently we need
to change the code to explicitly use the Python 3.4 interpreter. This
was already reflected in the package dependencies.