### PR TITLE
object_stats: Emit deletion timestamps as metric

### DIFF
--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -196,12 +196,20 @@ def relative_timestamp:
       "value": .,
       "uom": "c"
     },
-    {
-      "label": "elapsed",
-      "value": (now - .) | floor,
-      "uom": "s",
-      "min": 0
-    }
+    (
+      now as $now |
+      # Emit only when timestamp is in the past
+      if $now >= . then
+        {
+          "label": "elapsed",
+          "value": ($now - .) | floor,
+          "uom": "s",
+          "min": 0
+        }
+      else
+        empty
+      end
+    )
   )
 ;
 
@@ -235,6 +243,17 @@ reduce .items[] as $obj ({};
         "value": 1,
         "min": 0
       }
+    ),
+
+    (
+      ($obj.metadata.deletionTimestamp | parse_timestamp) as $deletion_ts |
+      if $deletion_ts then
+        $deletion_ts |
+        relative_timestamp |
+        .label |= "\($obj_prefix).deletion.\(.)"
+      else
+        empty
+      end
     ),
 
     if $kind == "cronjob" then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.18.2) xenial; urgency=medium
+
+  check_openshift_object_stats:
+  * Emit object deletion timestamp as metric.
+
+ -- Michael Hanselmann <hansmi@vshn.ch>  Tue, 28 May 2019 16:22:07 +0200
+
 nagios-plugins-openshift (0.18.1) xenial; urgency=medium
 
   check_openshift_es_stats:

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.18.1
+Version: 0.18.2
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -55,6 +55,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Tue May 28 2019 Michael Hanselmann <hansmi@vshn.ch> 0.18.2-1
+- check_openshift_object_stats:
+  - Emit object deletion timestamp as metric.
+
 * Fri May 24 2019 Michael Hanselmann <hansmi@vshn.ch> 0.18.1-1
 - check_openshift_es_stats:
   - Actually report JVM heap stats, used to be filesystem stats since version


### PR DESCRIPTION
Pods stuck in a terminal state would usually only be noticed by
a person. With this change a new metric is emitted when any of the
objects encountered by "check_openshift_object_stats" has a deletion
timestamp, defined by the API as "time when object is no longer expected
to exist", that is after the grace period.