### PR TITLE
Ignore failed count when determining whether Job succeeded

### DIFF
--- a/check_openshift_object_stats
+++ b/check_openshift_object_stats
@@ -301,7 +301,6 @@ reduce .items[] as $obj ({};
         ($job_status.startTime? | parse_timestamp) as $start_time_ts |
         ($job_status.completionTime? | parse_timestamp) as $completion_time_ts |
         ($completion_time_ts and
-         ($job_status.failed // 0) == 0 and
          ($job_status.active // 0) == 0 and
          ($job_status.succeeded // 0) > 0) as $successful |
 


### PR DESCRIPTION
The Kubernetes job controller will only set the completion time on a Job
when the job's succeeded count is >= the Job's `.spec.completions` field
if the field is set, or 1 otherwise.  The controller will retry the job
unless the retries have exceeded `.spec.backoffLimit`.

Therefore a Job can have a failed count of > 0 and a succeeded count of > 0
while still counting as successful, contrary to the previous
implementation of the object_stats check.

This commit removes the condition of requiring a failed count == 0 to
treat a Job execution as successful, as the presence of a completion
timestamp in conjunction with no active jobs and > 0 completed jobs is
sufficient to determine that a Job completed successfully, see the Job
controller implementation [1].

[1] https://github.com/kubernetes/kubernetes/blob/8211cabfb2bf3b2b531b13589843130cb47df1b1/pkg/controller/job/job_controller.go#L518-L570