### PR TITLE
new-app-and-wait: Add workaround token generation delayed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.18.5) xenial; urgency=medium
+
+  new-app-and-wait:
+  * Add workaround for service account token generation is delayed.
+
+ -- Gabriel Mainberger <gabriel.mainberger@vshn.ch>  Mon, 17 Jun 2019 15:08:21 +0200
+
 nagios-plugins-openshift (0.18.4) xenial; urgency=medium
 
   check_openshift_object_stats:

--- a/new-app-and-wait
+++ b/new-app-and-wait
@@ -240,6 +240,9 @@ def main():
   parser.add_argument("--pattern-from", type=argparse.FileType("r"),
                       default=None, metavar="FILE",
                       help="Load expected pattern from file")
+  parser.add_argument("--project-initial-wait", type=int, metavar="SEC", default=3,
+                      help=("Wait for given number of seconds after creating"
+                            " the project until starting the build"))
   parser.add_argument("config", type=str,
                       help="Configuration file with login credentials")
   parser.add_argument("source", type=str,
@@ -274,6 +277,10 @@ def main():
     project_name = oc_client.create_project(cl, namer)
 
     cl.namespace = project_name
+
+    # Workaround for service account token generation is delayed
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1719792
+    time.sleep(args.project_initial_wait)
 
     try:
       (url, duration) = Check(cl, args, timeout)

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.18.4
+Version: 0.18.5
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -55,6 +55,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Mon Jun 17 2019 Gabriel Mainberger <gabriel.mainberger@vshn.ch> 0.18.5-1
+- new-app-and-wait:
+  - Add workaround for service account token generation is delayed.
+
 * Thu Jun 6 2019 Michael Hanselmann <hansmi@vshn.ch> 0.18.4-1
 - check_openshift_object_stats:
   - Ignore failed count when determining whether Job succeeded.


### PR DESCRIPTION
The creation of the builder service account token is delayed
on HA master environments. This causes rarely the situation
a build is started without an accessible access token and
stick in the state new. To reduce the chance to get into
this situation, a sleep of 3 seconds is added between
creating the project and starting the build.

For more information about this known bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1719792