### PR TITLE
Adding OSCP 4 support to `check_openshift_node`

### DIFF
--- a/check_openshift_node
+++ b/check_openshift_node
@@ -92,7 +92,20 @@ check_condition() {
 check_condition Ready true
 check_condition DiskPressure false
 check_condition MemoryPressure false
-check_condition OutOfDisk false
+
+# Get Kubernetes version
+get_kube_ver
+
+# Depending on the Kubernetes version include additional Node info
+if [[ ${kube_major_ver} -ge 1 ]]; then
+  if [[ ${kube_minor_ver} -le 11 ]]; then
+    # OpenShift 3.x used up to Kubernetes 1.11
+    check_condition OutOfDisk false
+  elif [[ ${kube_minor_ver} -ge 12 ]]; then
+    # OpenShift 4.x starts at Kubernetes 1.12
+    check_condition PIDPressure false
+  fi
+fi
 
 finish "$exit_status" \
   "$(join_args ', ' ${output[@]+"${output[@]}"})" \

--- a/utils
+++ b/utils
@@ -5,7 +5,14 @@ readonly state_warning=1
 readonly state_critical=2
 readonly state_unknown=3
 
-readonly OPENSHIFT_CLIENT_BINARY=/usr/bin/oc
+# Set `oc` location
+# dynamically locate `oc` with which, but if that fails fall back
+# to static location of /usr/bin/oc
+if which oc >> /dev/null 2>&1; then
+  readonly OPENSHIFT_CLIENT_BINARY=$(which oc)
+else
+  readonly OPENSHIFT_CLIENT_BINARY=/usr/bin/oc
+fi
 
 #
 # Print arguments joined by delimiter
@@ -167,6 +174,31 @@ finish() {
 
   echo "$prefix${output:+ $output}${metrics:+ | $metrics}"
   exit "$exit_status"
+}
+
+#
+# Determine Kubernetes version
+#
+get_kube_ver() {
+  # oc >= 4 has `oc version -o json` however oc <= 3 does not
+  # so we need to parse stdout to figure out what version is being used
+  oc_ver_out=$(run_oc "$opt_cfgfile" version)
+  if echo "${oc_ver_out}" | grep -q 'kubernetes'; then
+    # OpenShift 3 formatting
+    kube_major_ver=$(echo "${oc_ver_out}" | grep 'kubernetes' | cut -d' ' -f 2 | cut -d'v' -f 2 | cut -d'+' -f 1 | tail -n1 | cut -d'.' -f 1)
+    export kube_major_ver
+    kube_minor_ver=$(echo "${oc_ver_out}" | grep 'kubernetes' | cut -d' ' -f 2 | cut -d'v' -f 2 | cut -d'+' -f 1 | tail -n1 | cut -d'.' -f 2)
+    export kube_minor_ver
+  elif echo "${oc_ver_out}" | grep -q 'Kubernetes Version'; then
+    # OpenShift 4 formatting
+    kube_major_ver=$(echo "${oc_ver_out}" | grep 'Kubernetes' | cut -d' ' -f 3 | cut -d'v' -f 2 | cut -d'+' -f 1 | tail -n1 | cut -d'.' -f 1)
+    export kube_major_ver
+    kube_minor_ver=$(echo "${oc_ver_out}" | grep 'Kubernetes' | cut -d' ' -f 3 | cut -d'v' -f 2 | cut -d'+' -f 1 | tail -n1 | cut -d'.' -f 2)
+    export kube_minor_ver
+  else
+    output+=( "Could not determine Kubernetes version" )
+    exit_status=$(merge_status "$exit_status" "$state_critical")
+  fi
 }
 
 # vim: set sw=2 sts=2 et :


### PR DESCRIPTION
- Added `get_kube_ver` function to `utils` which gets Kubernetes version
- Updated `check_openshift_node` so it checks OutOfDisk on OSCP 3
- Updated `check_openshift_node` so it checks PIDPressure on OSCP 4
- Updated `utils` to dynamically find `oc` and if it fails falls back to
  static location