### PR TITLE
new-app-and-wait: Additionally expose test application over HTTPS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017, VSHN AG, info@vshn.ch
+Copyright (c) 2016-2020, VSHN AG, info@vshn.ch
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nagios-plugins-openshift (0.18.15) xenial; urgency=medium
+
+  new-app-and-wait:
+  - Expose application over HTTPS in addition to HTTP.
+
+ -- Simon Gerber <simon.gerber@vshn.ch>  Wed, 26 Aug 2020 11:35:50 +0200
+
 nagios-plugins-openshift (0.18.14) xenial; urgency=medium
 
   check_openshift_pv_avail:

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: nagios-plugins-openshift
 Section: net
 Priority: optional
-Maintainer: Michael Hanselmann <hansmi@vshn.ch>
+Maintainer: VSHN AG <info@vshn.ch>
 Build-Depends: debhelper (>= 8.0.0),
  python3,
  python3-setuptools,

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,7 +2,7 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: nagios-plugins-docker
 
 Files: *
-Copyright: 2016-2017, VSHN AG, info@vshn.ch
+Copyright: 2016-2020, VSHN AG, info@vshn.ch
 License: BSD-3-clause
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/new-app-and-wait
+++ b/new-app-and-wait
@@ -147,6 +147,11 @@ def Check(client, args, timeout):
       })
 
   client.run(["expose", "svc", appname])
+  # This is required for some cases where a CDN is running in
+  # front of the cluster and the CDN only makes HTTPS connections to the
+  # backends. We always patch the route to be available over HTTP and HTTPS.
+  client.run(["patch", "route", appname, "-p",
+    '{"spec":{"tls":{"termination":"Edge","insecureEdgeTerminationPolicy":"Allow"}}}'])
 
   # Construct application URL
   route = client.capture_json(["get", "--output=json", "route", appname])

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -6,7 +6,7 @@ License: BSD-3-Clause
 Source: .
 URL: https://github.com/appuio/nagios-plugins-openshift
 Vendor: VSHN AG
-Packager: Michael Hanselmann <hansmi@vshn.ch>
+Packager: VSHN AG <info@vshn.ch>
 BuildRequires: python34-devel
 Requires: bash
 Requires: curl >= 7.21.3

--- a/redhat/nagios-plugins-openshift.spec
+++ b/redhat/nagios-plugins-openshift.spec
@@ -1,6 +1,6 @@
 Summary: Monitoring scripts for OpenShift
 Name: nagios-plugins-openshift
-Version: 0.18.14
+Version: 0.18.15
 Release: 1
 License: BSD-3-Clause
 Source: .
@@ -55,6 +55,10 @@ make 'LIBDIR=%{_libdir}' 'DATADIR=%{_datadir}'
 %{_datadir}/icinga2/include/plugins-contrib.d/*.conf
 
 %changelog
+* Tue Aug 25 2020 Simon Gerber <simon.gerber@vshn.ch> 0.18.15-1
+- new-app-and-wait:
+  - Expose application over HTTPS in addtion to HTTP.
+
 * Mon Jun 8 2020 Sandro Kaspar <sandro.kaspar@vshn.ch> 0.18.14-1
 - check_openshift_pv_avail:
   - Add option to ignore entire storageclasses.


### PR DESCRIPTION
This allows new-app-and-wait to work through CDNs which only make HTTPS backend connections.